### PR TITLE
Feature RAG with Role Base Access Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A modular Retrieval-Augmented Generation (RAG) repository with swappable pipelin
 - Basic text RAG (GROQ)
 - Multi-modal RAG (text + images via CLIP + GPT‑4.1)
 - LangGraph RAG (two-node graph: retrieve → generate)
+- rag-ubac: Role-based access control (UBAC) RAG
 
 Answers are grounded: the system answers ONLY using retrieved context; otherwise it replies:
 "I am a helpful assitant for you to assist with the internal knowledge base; No related contents retrived for the provided query - Try modifying your query for assistance."
@@ -25,6 +26,7 @@ Answers are grounded: the system answers ONLY using retrieved context; otherwise
   - `data/source_data/basic-rag/`
   - `data/source_data/multi-modal/`
   - `data/source_data/langgraph/`
+  - `data/source_data/rag-ubac/`
 
 2) Environment (.env)
 - GROQ (basic, langgraph):
@@ -68,6 +70,14 @@ pip install -r requirements.txt
   python main.py --rag_type langgraph --info
   ```
 
+- rag-ubac
+  You will be prompted to enter your role (executive/hr/junior). Answers are restricted by role-based access. UBAC uses metadata filters; re-run vectorization after updating FILE_ACCESS_METADATA.
+  ```
+  python main.py --rag_type rag-ubac --vectorize
+  python main.py --rag_type rag-ubac
+  python main.py --rag_type rag-ubac --info
+  ```
+
 - Manage collections (ChromaDB)
   ```
   python main.py --rag_type basic-rag --list-collections
@@ -78,7 +88,7 @@ pip install -r requirements.txt
 
 Data directory is inferred from the RAG type:
 ```
-data/source_data/{basic-rag | multi-modal | langgraph}
+data/source_data/{basic-rag | multi-modal | langgraph | rag-ubac}
 ```
 
 ## Grounded Prompts
@@ -92,10 +102,12 @@ data/source_data/{basic-rag | multi-modal | langgraph}
   - `basic_rag_retriever.py`
   - `multi_modal_retriever.py`
   - `langgraph_retriever.py`
+  - `rag_ubac_retriever.py`
 - `projects/pipeline/`
   - `basic_rag_pipeline.py`
   - `multi_modal_rag_pipeline.py`
   - `langgraph_rag_pipeline.py`
+  - `rag_ubac_pipeline.py`
 - `projects/prompts/`
   - `prompts.py` (basic)
   - `multi_modal_prompts.py`
@@ -103,9 +115,13 @@ data/source_data/{basic-rag | multi-modal | langgraph}
 - `shared/utils/`
   - `pdf_utils.py` (PyMuPDF)
   - `chroma_utils.py` (PersistentClient, collection helpers)
+  - `rag_ubac_scripts.py`
+- `shared/configs/`
+  - `static.py` (FILE_ACCESS_METADATA, VALID_ROLES, RAG_UBAC_TYPE)
 
 ## Tutorials
 
 - Basic RAG: `docs/tutorials/basic-rag-tutorial.md`
 - Multi‑Modal RAG: `docs/tutorials/multi-modal-rag.md`
 - RAG using Langgraph: `docs/tutorials/langgraph-rag.md`
+- RAG-UBAC tutorial: see `docs/tutorials/rag-ubac-tutorial.md`

--- a/docs/tutorials/rag-ubac-tutorial.md
+++ b/docs/tutorials/rag-ubac-tutorial.md
@@ -1,0 +1,82 @@
+## RAG-UBAC Tutorial
+
+This tutorial shows how to use the role-based access control (UBAC) RAG pipeline.
+
+### 1. What is RAG-UBAC?
+
+RAG-UBAC enforces role-based access during retrieval by attaching access metadata to chunks and filtering results according to a user’s role.
+
+- Roles: `executive`, `hr`, `junior`
+- Documents (example set in `data/source_data/rag-ubac/`):
+  - `Executive-Strategy.pdf` → executive only
+  - `HR-Policies-and-Benefits.pdf` → executive, hr
+  - `Onboarding-Guide-Junior.pdf` → executive, hr, junior
+
+### 2. Configuration
+
+Edit `shared/configs/static.py`:
+- `FILE_ACCESS_METADATA`: maps filename → base access level
+- `VALID_ROLES`: allowed user roles
+- `RAG_UBAC_TYPE`: `"rag-ubac"`
+- `PERSIST_DIR`, `EMBEDDING_MODEL`, `GROQ_MODEL`: runtime configs
+
+Example:
+```python
+FILE_ACCESS_METADATA = {
+    "Executive-Strategy.pdf": "executive",
+    "HR-Policies-and-Benefits.pdf": "hr",
+    "Onboarding-Guide-Junior.pdf": "junior"
+}
+```
+
+### 3. Index your data
+
+Place PDFs into `data/source_data/rag-ubac/`, then run:
+```bash
+python main.py --rag_type rag-ubac --vectorize
+```
+
+This:
+- Reads PDFs with PyMuPDF
+- Splits into chunks
+- Writes to Chroma with per-chunk metadata
+
+### 4. Ask questions
+
+```bash
+python main.py --rag_type rag-ubac
+```
+
+You’ll be prompted for your role:
+- `executive`: can access all
+- `hr`: can access HR + onboarding
+- `junior`: can access onboarding only
+
+Examples:
+- As `junior`, asking about HR policy should return the “no related contents” guardrail.
+- As `hr`, asking about executive strategy should be restricted.
+
+### 5. Internals
+
+- Pipeline: `projects/pipeline/rag_ubac_pipeline.py`
+- Retriever: `projects/retriever/rag_ubac_retriever.py`
+  - Indexing attaches `access_role` per chunk (duplicated per allowed role)
+  - Retrieval uses Chroma filter: `{"access_role": {"$eq": "<role>"}}`
+- Role prompt: `shared/components/rag_ubac_scripts.py`
+
+### 6. Maintenance tips
+
+- If you add more documents or roles, update `FILE_ACCESS_METADATA` and re-vectorize.
+- To reset or remove the collection:
+```bash
+python main.py --delete-collection --rag_type rag-ubac
+```
+- List all collections:
+```bash
+python main.py --list-collections
+```
+
+### 7. Troubleshooting
+
+- “No related contents” for allowed role: ensure the file is correctly mapped in `FILE_ACCESS_METADATA` and re-vectorize.
+- Metadata filter errors: confirm metadata fields are simple types (strings) and operator is `$eq`.

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from projects.pipeline.basic_rag_pipeline import BasicRAGPipeline
 from projects.pipeline.multi_modal_rag_pipeline import MultiModalRAGPipeline
 from projects.pipeline.langgraph_rag_pipeline import LangGraphRAGPipeline
 from shared.utils.chroma_utils import list_existing_collections, delete_collection
-from shared.configs.static import RAG_TYPES, DATA_DIR_MAP
+from shared.configs.static import RAG_TYPES, DATA_DIR_MAP, VALID_ROLES
 from projects.pipeline.rag_ubac_pipeline import RAGUBACPipeline
 
 def main():
@@ -51,14 +51,8 @@ def main():
     elif args.rag_type == "multi-modal":
         rag = MultiModalRAGPipeline(data_dir)
     elif args.rag_type == "rag-ubac":
-        # Prompt for role/persona
-        valid_roles = {"executive", "hr", "junior"}
-        role = ""
-        while role not in valid_roles:
-            role = input("Enter your role (executive/hr/junior): ").strip().lower()
-            if role not in valid_roles:
-                print("Invalid role. Please choose one of: executive, hr, junior.")
-        rag = RAGUBACPipeline(data_dir, role=role, rag_type=args.rag_type)
+        
+        rag = RAGUBACPipeline(data_dir, rag_type=args.rag_type)
     else:
         rag = LangGraphRAGPipeline(data_dir)
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from projects.pipeline.multi_modal_rag_pipeline import MultiModalRAGPipeline
 from projects.pipeline.langgraph_rag_pipeline import LangGraphRAGPipeline
 from shared.utils.chroma_utils import list_existing_collections, delete_collection
 from shared.configs.static import RAG_TYPES, DATA_DIR_MAP
+from projects.pipeline.rag_ubac_pipeline import RAGUBACPipeline
 
 def main():
     parser = argparse.ArgumentParser(description="RAG Pipeline CLI")
@@ -49,6 +50,15 @@ def main():
         rag = BasicRAGPipeline(data_dir, rag_type=args.rag_type)
     elif args.rag_type == "multi-modal":
         rag = MultiModalRAGPipeline(data_dir)
+    elif args.rag_type == "rag-ubac":
+        # Prompt for role/persona
+        valid_roles = {"executive", "hr", "junior"}
+        role = ""
+        while role not in valid_roles:
+            role = input("Enter your role (executive/hr/junior): ").strip().lower()
+            if role not in valid_roles:
+                print("Invalid role. Please choose one of: executive, hr, junior.")
+        rag = RAGUBACPipeline(data_dir, role=role, rag_type=args.rag_type)
     else:
         rag = LangGraphRAGPipeline(data_dir)
 

--- a/projects/pipeline/rag_ubac_pipeline.py
+++ b/projects/pipeline/rag_ubac_pipeline.py
@@ -3,6 +3,8 @@ from dotenv import load_dotenv
 from langchain_groq import ChatGroq
 from projects.retriever.rag_ubac_retriever import RAGUBACRetriever
 from projects.prompts.prompts import BASIC_RAG_PROMPT
+from shared.configs.static import PERSIST_DIR, GROQ_MODEL, RAG_UBAC_TYPE
+from shared.components.rag_ubac_scripts import get_ubac_role
 
 load_dotenv()
 
@@ -10,13 +12,12 @@ class RAGUBACPipeline:
     def __init__(
         self,
         data_dir,
-        persist_directory="chroma_db",
-        groq_model="openai/gpt-oss-20b",
-        rag_type="rag-ubac",
-        role="executive"
+        persist_directory=PERSIST_DIR,
+        groq_model=GROQ_MODEL,
+        rag_type=RAG_UBAC_TYPE
     ):
         self.rag_type = rag_type
-        self.role = role
+        self.role = get_ubac_role()
         self.retriever = RAGUBACRetriever(data_dir, persist_directory, rag_type)
         self.llm = ChatGroq(
             temperature=0.2,

--- a/projects/pipeline/rag_ubac_pipeline.py
+++ b/projects/pipeline/rag_ubac_pipeline.py
@@ -1,0 +1,39 @@
+import os
+from dotenv import load_dotenv
+from langchain_groq import ChatGroq
+from projects.retriever.rag_ubac_retriever import RAGUBACRetriever
+from projects.prompts.prompts import BASIC_RAG_PROMPT
+
+load_dotenv()
+
+class RAGUBACPipeline:
+    def __init__(
+        self,
+        data_dir,
+        persist_directory="chroma_db",
+        groq_model="openai/gpt-oss-20b",
+        rag_type="rag-ubac",
+        role="executive"
+    ):
+        self.rag_type = rag_type
+        self.role = role
+        self.retriever = RAGUBACRetriever(data_dir, persist_directory, rag_type)
+        self.llm = ChatGroq(
+            temperature=0.2,
+            model=groq_model,
+            api_key=os.getenv("GROQ_API_KEY")
+        )
+
+    def answer(self, query, top_k=3):
+        contexts = self.retriever.retrieve(query, role=self.role, top_k=top_k)
+        context = "\n".join(contexts)
+        if not context.strip():
+            return 'I am a helpful assitant for you to assist with the internal knowledge base; No related contents retrived for the provided query - Try modifying your query for assistance.'
+        prompt = BASIC_RAG_PROMPT.format(context=context, question=query)
+        response = self.llm.invoke(prompt)
+        return response.content if hasattr(response, 'content') else response
+
+    def get_pipeline_info(self):
+        info = self.retriever.get_collection_info()
+        info["role"] = self.role
+        return info

--- a/projects/retriever/rag_ubac_retriever.py
+++ b/projects/retriever/rag_ubac_retriever.py
@@ -1,0 +1,174 @@
+import os
+import fitz  # PyMuPDF
+from langchain_chroma import Chroma
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from dotenv import load_dotenv
+from shared.utils.chroma_utils import get_collection_name_for_rag_type
+from shared.configs.static import FILE_ACCESS_METADATA, VALID_ROLES
+
+load_dotenv()
+
+class RAGUBACRetriever:
+    def __init__(self, data_dir, persist_directory="chroma_db", rag_type="rag-ubac"):
+        self.data_dir = data_dir
+        self.persist_directory = persist_directory
+        self.rag_type = rag_type
+        self.collection_name = get_collection_name_for_rag_type(rag_type)
+        self.embedding = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+        self.text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+        self.vectorstore = None
+
+    def _get_access_levels_for_role(self, role: str):
+        """Determine which documents a role can access based on hierarchy."""
+        if role == "executive":
+            # Executive can access all documents
+            return list(FILE_ACCESS_METADATA.keys())
+        elif role == "hr":
+            # HR can access HR policies and onboarding (but not executive strategy)
+            return [filename for filename, access_level in FILE_ACCESS_METADATA.items() 
+                   if access_level in ["hr", "junior"]]
+        elif role == "junior":
+            # Junior can only access onboarding guide
+            return [filename for filename, access_level in FILE_ACCESS_METADATA.items() 
+                   if access_level == "junior"]
+        else:
+            return []
+
+    def _allowed_roles_for_file(self, filename: str):
+        """Get all roles that can access a specific file."""
+        base_access = FILE_ACCESS_METADATA.get(filename, "executive")
+        if base_access == "executive":
+            return ["executive"]
+        elif base_access == "hr":
+            return ["executive", "hr"]
+        elif base_access == "junior":
+            return ["executive", "hr", "junior"]
+        return ["executive"]  # Default fallback
+
+    def index_pdfs(self):
+        """Index PDFs with metadata based on FILE_ACCESS_METADATA."""
+        print(f"Indexing PDFs for UBAC collection: {self.collection_name}")
+        docs = []
+        
+        for filename in os.listdir(self.data_dir):
+            if not filename.lower().endswith(".pdf"):
+                continue
+                
+            pdf_path = os.path.join(self.data_dir, filename)
+            
+            # Check if file is in our access metadata
+            if filename not in FILE_ACCESS_METADATA:
+                print(f"Warning: {filename} not found in FILE_ACCESS_METADATA, defaulting to executive-only access")
+                base_access = "executive"
+            else:
+                base_access = FILE_ACCESS_METADATA[filename]
+            
+            try:
+                doc = fitz.open(pdf_path)
+                text = ""
+                for page in doc:
+                    text += page.get_text()
+                doc.close()
+            except Exception as e:
+                print(f"Failed to read {pdf_path}: {e}")
+                continue
+
+            # Create metadata for each chunk
+            allowed_roles = self._allowed_roles_for_file(filename)
+            metadatas = [{
+                "source": filename, 
+                "base_access_level": base_access,
+                "allowed_roles": allowed_roles,
+                "file_type": "pdf"
+            }]
+            
+            # Split text into chunks with metadata
+            chunks = self.text_splitter.create_documents([text], metadatas=metadatas)
+            docs.extend(chunks)
+
+        if not docs:
+            print("No documents to index for UBAC.")
+            return
+
+        self.vectorstore = Chroma.from_documents(
+            docs,
+            self.embedding,
+            persist_directory=self.persist_directory,
+            collection_name=self.collection_name
+        )
+        print(f"Successfully indexed {len(docs)} chunks in UBAC collection: {self.collection_name}")
+        print(f"Access levels: {FILE_ACCESS_METADATA}")
+
+    def _ensure_store(self):
+        """Ensure vectorstore is loaded."""
+        if self.vectorstore is None:
+            print(f"Loading existing vector store for UBAC collection: {self.collection_name}")
+            self.vectorstore = Chroma(
+                persist_directory=self.persist_directory,
+                embedding_function=self.embedding,
+                collection_name=self.collection_name
+            )
+
+    def retrieve(self, query, role: str, top_k=3):
+        """Retrieve documents based on role-based access control."""
+        self._ensure_store()
+        role = (role or "").lower().strip()
+        
+        if role not in VALID_ROLES:
+            print(f"Unknown role '{role}'. Valid roles are: {VALID_ROLES}")
+            return []
+        
+        # Get documents this role can access
+        accessible_files = self._get_access_levels_for_role(role)
+        if not accessible_files:
+            print(f"Role '{role}' has no access to any documents.")
+            return []
+        
+        # Create filter for ChromaDB based on allowed roles
+        chroma_filter = {"allowed_roles": {"$in": [role]}}
+        
+        try:
+            docs = self.vectorstore.similarity_search(query, k=top_k, filter=chroma_filter)
+            retrieved_sources = set(doc.metadata.get("source", "") for doc in docs)
+            print(f"Retrieved from sources: {retrieved_sources}")
+            return [doc.page_content for doc in docs]
+        except Exception as e:
+            print(f"Error during retrieval: {e}")
+            return []
+
+    def get_collection_info(self):
+        """Get information about the current collection."""
+        self._ensure_store()
+        try:
+            count = self.vectorstore._collection.count()
+            return {
+                "collection_name": self.collection_name,
+                "document_count": count,
+                "rag_type": self.rag_type,
+                "file_access_metadata": FILE_ACCESS_METADATA,
+                "valid_roles": list(VALID_ROLES)
+            }
+        except Exception as e:
+            return {
+                "collection_name": self.collection_name,
+                "document_count": 0,
+                "rag_type": self.rag_type,
+                "error": str(e),
+                "file_access_metadata": FILE_ACCESS_METADATA,
+                "valid_roles": list(VALID_ROLES)
+            }
+
+    def get_role_access_info(self, role: str):
+        """Get information about what documents a specific role can access."""
+        if role not in VALID_ROLES:
+            return {"error": f"Invalid role: {role}"}
+        
+        accessible_files = self._get_access_levels_for_role(role)
+        return {
+            "role": role,
+            "accessible_files": accessible_files,
+            "total_files": len(FILE_ACCESS_METADATA),
+            "access_level": "full" if role == "executive" else "restricted"
+        }
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ langchain-community
 langchain-groq
 langchain-chroma
 langchain-huggingface
-langgraph>=0.2.0
+langgraph>=0.3.0
 transformers>=4.39.0
-torch>=2.2.0
+torch>=2.2.0,<2.3.0
+torchvision>=0.17.0,<0.18.0
 Pillow>=10.0.0
 PyMuPDF
 python-dotenv

--- a/shared/components/rag_ubac_scripts.py
+++ b/shared/components/rag_ubac_scripts.py
@@ -1,0 +1,15 @@
+from shared.configs.static import VALID_ROLES 
+
+def get_ubac_role():
+    # Prompt for role/persona
+    role, _try = "", 0
+    while role not in VALID_ROLES and _try < 3:
+        role = input("Enter your role (executive/hr/junior): ").strip().lower()
+        if role not in VALID_ROLES:
+            print("Invalid role. Please choose one of: executive, hr, junior.")
+            _try += 1
+        if _try == 2:
+            print("You are exceeded maximum number of attempt; please refer the persona documentation for more referenece")
+            return None
+    
+    return role

--- a/shared/components/rag_ubac_scripts.py
+++ b/shared/components/rag_ubac_scripts.py
@@ -1,15 +1,37 @@
-from shared.configs.static import VALID_ROLES 
+from shared.configs.static import VALID_ROLES
 
 def get_ubac_role():
-    # Prompt for role/persona
+    """Prompt user to select their role for UBAC access control."""
+    print("\n=== Role-Based Access Control ===")
+    print("Please select your role to determine document access:")
+    print("1. executive - Full access to all documents")
+    print("2. hr - Access to HR policies and onboarding (no executive strategy)")
+    print("3. junior - Access only to onboarding guide")
+    
     role, _try = "", 0
     while role not in VALID_ROLES and _try < 3:
         role = input("Enter your role (executive/hr/junior): ").strip().lower()
         if role not in VALID_ROLES:
             print("Invalid role. Please choose one of: executive, hr, junior.")
+            if _try == 2:
+                print("You are exceeded maximum number of attempt; please refer the persona documentation for more referenece")
+                return None
             _try += 1
-        if _try == 2:
-            print("You are exceeded maximum number of attempt; please refer the persona documentation for more referenece")
-            return None
-    
     return role
+
+def display_access_info(role):
+    """Display what documents the user can access."""
+    if role == "executive":
+        print("✓ Executive Strategy")
+        print("✓ HR Policies and Benefits") 
+        print("✓ Onboarding Guide")
+    elif role == "hr":
+        print("✗ Executive Strategy (restricted)")
+        print("✓ HR Policies and Benefits")
+        print("✓ Onboarding Guide")
+    elif role == "junior":
+        print("✗ Executive Strategy (restricted)")
+        print("✗ HR Policies and Benefits (restricted)")
+        print("✓ Onboarding Guide")
+    else:
+        print(f"No details found for the role: {role}")

--- a/shared/configs/static.py
+++ b/shared/configs/static.py
@@ -1,10 +1,11 @@
 # Command line arguments
-RAG_TYPES = ["basic-rag", "multi-modal", "langgraph"]
+RAG_TYPES = ["basic-rag", "multi-modal", "langgraph", "rag-ubac"]
 # Data dir per type
 DATA_DIR_MAP = {
     "basic-rag": "data/source_data/basic-rag",
     "multi-modal": "data/source_data/multi-modal",
     "langgraph": "data/source_data/langgraph",
+    "rag-ubac": "data/source_data/rag-ubac",
 }
 
 # Vector Database

--- a/shared/configs/static.py
+++ b/shared/configs/static.py
@@ -23,3 +23,12 @@ CLIP_PROCESSOR = "openai/clip-vit-base-patch32"
 
 # Langgraph
 LG_RAG_TYPE = "langgraph"
+
+# RAG-UBAC
+VALID_ROLES = {"executive", "hr", "junior"}
+FILE_ACCESS_METADATA = {
+    "Executive-Strategy.pdf":"executive", 
+    "HR-Policies-and-Benefits.pdf":"hr", 
+    "Onboarding-Guide-Junior.pdf":"junior"
+}
+RAG_UBAC_TYPE = "rag-ubac"

--- a/shared/utils/chroma_utils.py
+++ b/shared/utils/chroma_utils.py
@@ -2,7 +2,7 @@ import chromadb
 from chromadb.config import Settings
 import os
 
-allowed_collection_types = ["basic_rag_collection", "multi_modal_collection", "langgraph_collection"]
+allowed_collection_types = ["basic_rag_collection", "multi_modal_collection", "langgraph_collection", "rag_ubac_collection"]
 
 def get_persistent_chroma_collection(
     collection_name: str = "basic_rag_collection",


### PR DESCRIPTION
RAG Pipeline with Role Base Access Control
- rag-ubac: Role-based access control (UBAC) RAG

- Roles: `executive`, `hr`, `junior`
- Documents (example set in `data/source_data/rag-ubac/`):
  - `Executive-Strategy.pdf` → executive only
  - `HR-Policies-and-Benefits.pdf` → executive, hr
  - `Onboarding-Guide-Junior.pdf` → executive, hr, junior